### PR TITLE
Handle HMAC signature length mismatch safely

### DIFF
--- a/lib/__tests__/hmac-signer.test.ts
+++ b/lib/__tests__/hmac-signer.test.ts
@@ -1,0 +1,20 @@
+import { verifySignature, signPayload } from '../hmac-signer';
+
+describe('verifySignature', () => {
+  it('returns false for signatures with different lengths', () => {
+    const payload = { foo: 'bar' };
+    const secret = 'test-secret';
+    const validSignature = signPayload(payload, secret);
+    const invalidSignature = validSignature.slice(0, -2); // shorter signature
+
+    expect(verifySignature(payload, secret, invalidSignature)).toBe(false);
+  });
+
+  it('returns true for valid signature', () => {
+    const payload = { foo: 'bar' };
+    const secret = 'test-secret';
+    const validSignature = signPayload(payload, secret);
+
+    expect(verifySignature(payload, secret, validSignature)).toBe(true);
+  });
+});

--- a/lib/hmac-signer.ts
+++ b/lib/hmac-signer.ts
@@ -31,12 +31,16 @@ export function signPayload(payload: any, secret: string): string {
  */
 export function verifySignature(payload: any, secret: string, signature: string): boolean {
   const expectedSignature = signPayload(payload, secret);
-  
+
+  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+  const providedBuffer = Buffer.from(signature, 'hex');
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
   // Use timing-safe comparison to prevent timing attacks
-  return crypto.timingSafeEqual(
-    Buffer.from(expectedSignature, 'hex'),
-    Buffer.from(signature, 'hex')
-  );
+  return crypto.timingSafeEqual(expectedBuffer, providedBuffer);
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid runtime errors when webhook signature length differs from expected
- cover hmac signer edge cases with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_688deac94834832f8370cd7537074fc2